### PR TITLE
fusion: preserve panel id

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It allows to update existing panels, while preserving the dashboard layout.
 
 Fusion is performed by merging panels from multiple sources into a single dashboard.
 - Panels are matched by title and type.
-- If a panel with the same title and type exists in the dashboard, its content will be replaced, except for its position (preserving the dashboard layout).
+- If a panel with the same title and type exists in the dashboard, its content will be replaced, except for its position (preserving the dashboard layout) and id.
 - If a panel with the same title and type does not exist in the dashboard, it will be appended to the end of the dashboard.
 Later, the dashboard can be manually reorganized to achieve the desired layout.
 

--- a/fusion.go
+++ b/fusion.go
@@ -28,6 +28,10 @@ func (p Panel) Equals(p2 Panel) bool {
 		bytes.Equal(p["type"], p2["type"])
 }
 
+func (p Panel) IDRaw() json.RawMessage {
+	return p["id"]
+}
+
 func (p Panel) GridPosRaw() json.RawMessage {
 	return p["gridPos"]
 }
@@ -54,7 +58,7 @@ type GridPos struct {
 // MergePanels merges two sets of panels.
 //
 // If a panel in ps2 matches a panel in ps1, the panel in ps2 overwrites the
-// content of the panel in ps1, but preserves its position.
+// content of the panel in ps1, but preserves its position and id.
 //
 // If a panel in ps2 does not match any panel in ps1 it is appended and placed at the end of the dashboard.
 func MergePanels(ps1, ps2 []Panel) []Panel {
@@ -75,8 +79,8 @@ func MergePanels(ps1, ps2 []Panel) []Panel {
 		for i := range res {
 			if res[i].Equals(p2) {
 				// When we find a match, the panel's content is overwritten,
-				// except for the gridPos(to preserve the layout).
-				p2["gridPos"] = res[i].GridPosRaw()
+				// except for the gridPos(to preserve the layout) and id.
+				p2["gridPos"], p2["id"] = res[i].GridPosRaw(), res[i].IDRaw()
 				res[i] = p2
 				matched = true
 			}

--- a/fusion_test.go
+++ b/fusion_test.go
@@ -25,11 +25,13 @@ func TestMergePanels(t *testing.T) {
 					"title":   json.RawMessage("Panel1"),
 					"type":    json.RawMessage("graph"),
 					"gridPos": json.RawMessage(`{"x":0,"y":0,"h":2,"w":6}`),
+					"id":      json.RawMessage("1"),
 				},
 				{
 					"title":   json.RawMessage("Panel2"),
 					"type":    json.RawMessage("row"),
 					"gridPos": json.RawMessage(`{"x":0,"y":2,"h":2,"w":6}`),
+					"id":      json.RawMessage("2"),
 				},
 			},
 			extra: []Panel{
@@ -37,6 +39,7 @@ func TestMergePanels(t *testing.T) {
 					"title":   json.RawMessage("Panel1"),
 					"type":    json.RawMessage("graph"),
 					"content": json.RawMessage("Wanted Content for Panel1"),
+					"id":      json.RawMessage("3"),
 				},
 			},
 			wanted: []Panel{
@@ -45,11 +48,13 @@ func TestMergePanels(t *testing.T) {
 					"type":    json.RawMessage("graph"),
 					"content": json.RawMessage("Wanted Content for Panel1"),
 					"gridPos": json.RawMessage(`{"x":0,"y":0,"h":2,"w":6}`),
+					"id":      json.RawMessage("1"),
 				},
 				{
 					"title":   json.RawMessage("Panel2"),
 					"type":    json.RawMessage("row"),
 					"gridPos": json.RawMessage(`{"x":0,"y":2,"h":2,"w":6}`),
+					"id":      json.RawMessage("2"),
 				},
 			},
 		},
@@ -60,11 +65,13 @@ func TestMergePanels(t *testing.T) {
 					"title":   json.RawMessage("Panel1"),
 					"type":    json.RawMessage("graph"),
 					"gridPos": json.RawMessage(`{"x":0,"y":0,"h":3,"w":5}`),
+					"id":      json.RawMessage("1"),
 				},
 				{
 					"title":   json.RawMessage("Panel2"),
 					"type":    json.RawMessage("row"),
 					"gridPos": json.RawMessage(`{"x":0,"y":2,"h":2,"w":6}`),
+					"id":      json.RawMessage("2"),
 				},
 			},
 			extra: []Panel{
@@ -72,6 +79,7 @@ func TestMergePanels(t *testing.T) {
 					"title":   json.RawMessage("Panel3"),
 					"type":    json.RawMessage("graph"),
 					"context": json.RawMessage("Wanted Content for Panel3"),
+					"id":      json.RawMessage("3"),
 				},
 			},
 			wanted: []Panel{
@@ -79,17 +87,20 @@ func TestMergePanels(t *testing.T) {
 					"title":   json.RawMessage("Panel1"),
 					"type":    json.RawMessage("graph"),
 					"gridPos": json.RawMessage(`{"x":0,"y":0,"h":3,"w":5}`),
+					"id":      json.RawMessage("1"),
 				},
 				{
 					"title":   json.RawMessage("Panel2"),
 					"type":    json.RawMessage("row"),
 					"gridPos": json.RawMessage(`{"x":0,"y":2,"h":2,"w":6}`),
+					"id":      json.RawMessage("2"),
 				},
 				{
 					"title":   json.RawMessage("Panel3"),
 					"type":    json.RawMessage("graph"),
 					"context": json.RawMessage("Wanted Content for Panel3"),
 					"gridPos": json.RawMessage(`{"h":2,"w":6,"x":0,"y":5}`),
+					"id":      json.RawMessage("3"),
 				},
 			},
 		},


### PR DESCRIPTION
Panels can have different IDs, even though they are the same. It can be caused by the order in which they were added to a dashboard.