### PR TITLE
cmd/dashboard-fusion: do not escape HTML

### DIFF
--- a/cmd/dashboard-fusion/main.go
+++ b/cmd/dashboard-fusion/main.go
@@ -68,6 +68,7 @@ func main() {
 
 	enc := json.NewEncoder(out)
 	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
 	if err := enc.Encode(d); err != nil {
 		log.Println("encoding output dashboard ", err)
 	}


### PR DESCRIPTION
It would cause '&' be printed as \u0026.